### PR TITLE
Fix mkdocs.yml file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,3 +14,15 @@ pages:
     - Facebook messenger: service/facebook.md
     - Other services: service/other.md
   - CiviRules integration: civirules-integration.md
+
+markdown_extensions:
+  - attr_list
+  - admonition
+  - def_list
+  - codehilite
+  - toc(permalink=true)
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.tilde
+  - pymdownx.betterem
+  - pymdownx.mark

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,6 @@
 site_name: CiviCRM chatbot
+site_description: A CiviCRM extension to provide an interface to common chat platforms.
+theme: material
 pages:
   - Introduction: index.md
   - Installation: installation.md


### PR DESCRIPTION
lack of "theme:" errors out MkDocs

matched syntax used in other extensions files.